### PR TITLE
[Feature][Network] Add a service that allows retrieving a MAC address

### DIFF
--- a/DataStructures.json
+++ b/DataStructures.json
@@ -68,3 +68,8 @@ var params = {
         "timeout": "3000"
 }
 lumitron.request.send("network", "isIpReachable", params);
+
+var params = {
+        "ip_address": "192.168.1.3"
+}
+lumitron.request.send("network", "getMacAddress", params);

--- a/Lumitron/src/main/java/com/lumitron/network/Network.java
+++ b/Lumitron/src/main/java/com/lumitron/network/Network.java
@@ -3,6 +3,7 @@ package com.lumitron.network;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Scanner;
 
 import com.lumitron.util.LumitronException;
 
@@ -28,5 +29,32 @@ public class Network {
         }
 
         return isIpReachable;
+    }
+
+    /**
+     * Retrieve the MAC Address by parsing the result of the Windows 'arp' command.
+     * It is advisable to ping the device before getting the MAC address to refresh the table content.
+     * Keep in mind that the returned MAC address corresponds to the last registered device in the table:
+     * the device could change, but if no packet is received from that new device, the MAC address is not updated.
+     * @param ipAddress The IP address
+     * @return A String representing the MAC address in the xx-xx-xx-xx-xx-xx format, or null if not found
+     * @throws LumitronException
+     */
+    public static String getMacAddressFromArpTable(String ipAddress) throws LumitronException {
+        String macAddress = null;
+
+        // Retrieve the Mac Address by parsing the result of the Windows 'arp' command
+        try {
+            // Execute the arp command
+            Process arpProcess = Runtime.getRuntime().exec("arp -a " + ipAddress);
+
+            // Parse the output of the command, looking for the MAC address if exists
+            Scanner s = new Scanner(arpProcess.getInputStream());
+            macAddress =  s.findWithinHorizon("([0-9a-fA-F]{2}-){5}([0-9a-fA-F]{2})", 0);
+        } catch (IOException e) {
+            throw new LumitronException(NetworkService.class.getSimpleName(), "0003", "An error occurred while retrieving the MAC Address");
+        }
+
+        return macAddress;
     }
 }

--- a/Lumitron/src/main/java/com/lumitron/network/NetworkHandler.java
+++ b/Lumitron/src/main/java/com/lumitron/network/NetworkHandler.java
@@ -18,4 +18,19 @@ public class NetworkHandler {
 
         return response;
     }
+
+    public static HashMap<String, String> getMacAddress(HashMap<String, String> params) {
+        // Get the parameters
+        String ipAddress = params.get("ip_address");
+
+        // Get the MAC address
+        String macAddress = Network.getMacAddressFromArpTable(ipAddress);
+
+        // Return the formatted response
+        HashMap<String, String> response = new HashMap<String, String>();
+        response.put("ip_address", ipAddress);
+        response.put("mac_address", (macAddress != null) ? macAddress : "");
+
+        return response;
+    }
 }

--- a/Lumitron/src/main/java/com/lumitron/network/NetworkHandler.java
+++ b/Lumitron/src/main/java/com/lumitron/network/NetworkHandler.java
@@ -13,23 +13,23 @@ public class NetworkHandler {
 
         // Return the formatted response
         HashMap<String, String> response = new HashMap<String, String>();
-        response.put("ip_address", ipAddress);
-        response.put("is_reachable", isIpReachable ? "true" : "false");
+        response.put("ipAddress", ipAddress);
+        response.put("isAlive", isIpReachable ? "true" : "false");
 
         return response;
     }
 
     public static HashMap<String, String> getMacAddress(HashMap<String, String> params) {
         // Get the parameters
-        String ipAddress = params.get("ip_address");
+        String ipAddress = params.get("ipAddress");
 
         // Get the MAC address
         String macAddress = Network.getMacAddressFromArpTable(ipAddress);
 
         // Return the formatted response
         HashMap<String, String> response = new HashMap<String, String>();
-        response.put("ip_address", ipAddress);
-        response.put("mac_address", (macAddress != null) ? macAddress : "");
+        response.put("ipAddress", ipAddress);
+        response.put("macAddress", (macAddress != null) ? macAddress : "");
 
         return response;
     }

--- a/Lumitron/src/main/java/com/lumitron/network/NetworkService.java
+++ b/Lumitron/src/main/java/com/lumitron/network/NetworkService.java
@@ -15,4 +15,8 @@ public class NetworkService implements LumitronService {
     public void isIpReachable() {
         RequestHandler.send(serviceRoute.get("uuid"), NetworkHandler.isIpReachable(params));
     }
+
+    public void getMacAddress() {
+        RequestHandler.send(serviceRoute.get("uuid"), NetworkHandler.getMacAddress(params));
+    }
 }

--- a/Lumitron/src/main/resources/serviceMapping.json
+++ b/Lumitron/src/main/resources/serviceMapping.json
@@ -32,6 +32,10 @@
         "isIpReachable": {
             "serviceClass": "com.lumitron.network.NetworkService",
             "method": "isIpReachable"
+        },
+        "getMacAddress": {
+            "serviceClass": "com.lumitron.network.NetworkService",
+            "method": "getMacAddress"
         }
     },
     "project": {


### PR DESCRIPTION
This pull requests adds the following features:
- Add a Network method that retrieves the MAC address from an IP address using the local ARP table (Windows only)
- Add a Network Service and a Handler for the new feature
- Map the new service
- Add an example of use
